### PR TITLE
Bug 16/limit option length to 255

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix two format arguments in debug output printing (fairly pedantic; not even
   caught by clang analyzer).
+- Limit DHCP options to 255 bytes (not 256).
+- Exit if a DHCP option is too long.
 
 ## 0.5.2 - 2019-05-09
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ endif()
 
 project(
 	${PROJECT}
-	VERSION 0.5.2
+	VERSION 0.5.3
 	DESCRIPTION "DHCP option injector"
 	LANGUAGES C
 	)

--- a/src/config.c
+++ b/src/config.c
@@ -317,7 +317,7 @@ static void printHelp(void)
 			"The option hex string is written as a series of two-digit pairs,\n"
 			"optionally delimited by one or more non-hexadecimal characters:\n"
 			"'466A6173','46 6A 61 73', '46:6A:61:73' etc. There is a maximum limit\n"
-			"of 256 bytes per option, excluding the option code (the first byte)\n"
+			"of 255 bytes per option, excluding the option code (the first byte)\n"
 			"and the automatically inserted length byte. At least one option must\n"
 			"be provided.\n"
 			"\n"
@@ -371,8 +371,8 @@ static void addDHCPOption(struct DHCPOptList *list, const char *string)
 	if (!string)
 		return;
 
-	/* Make room for length byte and payload */
-	uint8_t buffer[1 + 256];
+	/* Make room for option code byte and payload */
+	uint8_t buffer[1 + UINT8_MAX];
 	size_t length = 0;
 	for (size_t i = 0; i < strlen(string) && length < sizeof(buffer);)
 	{
@@ -384,8 +384,15 @@ static void addDHCPOption(struct DHCPOptList *list, const char *string)
 		else
 			++i;
 	}
+	/* Will not happen; the cmd.line parsing code expects an argument: */
 	if (!length)
 		return;
+	if (length > UINT8_MAX)
+	{
+		fprintf(stderr, "DHCP option size exceeds the limit of %u bytes\n",
+				UINT8_MAX);
+		exit(EXIT_FAILURE);
+	}
 
 	uint16_t optCode = buffer[0];
 

--- a/src/dhcpoptinj.c
+++ b/src/dhcpoptinj.c
@@ -654,9 +654,9 @@ static void debugLogOptionFound(const struct DHCPOption *option)
 
 static void debugLogOption(const char *action, const struct DHCPOption *option)
 {
-	/* String buffer for hex string (maximum DHCP option length (256) times
+	/* String buffer for hex string (maximum DHCP option length (255) times
 	 * three characters (two digits and a space)) */
-	char optPayload[256 * 3];
+	char optPayload[UINT8_MAX * 3];
 	size_t i = 0;
 	for (; i < option->length; ++i)
 		sprintf(optPayload + 3*i, "%02X ", option->data[i]);

--- a/src/options.c
+++ b/src/options.c
@@ -28,7 +28,7 @@ struct DHCPOpt
 {
 	uint8_t code;
 	uint8_t length;
-	uint8_t data[256];
+	uint8_t data[UINT8_MAX];
 };
 
 struct DHCPOptList


### PR DESCRIPTION
- Limit DHCP option length to 255
- Complain if DHCP option passed exceeds 255 bytes (the previous behaviour was to overwrite the buffer from the beginning and not complain)

Fixes #16.